### PR TITLE
fix: resolve non-interactive mode failures during onboarding

### DIFF
--- a/src/cli/Services/Git/GitService.cs
+++ b/src/cli/Services/Git/GitService.cs
@@ -31,6 +31,8 @@ public sealed class GitService : IGitService
         await CliWrap.Cli.Wrap(cli)
             .WithArguments(arguments)
             .WithValidation(CommandResultValidation.ZeroExitCode)
+            .WithStandardOutputPipe(PipeTarget.ToStream(Console.OpenStandardOutput()))
+            .WithStandardErrorPipe(PipeTarget.ToStream(Console.OpenStandardError()))
             .ExecuteAsync(cancellationToken);
 
         return await GetRepositoryAsync(path, cancellationToken);

--- a/src/hosting/build/Spire.Hosting.targets
+++ b/src/hosting/build/Spire.Hosting.targets
@@ -31,7 +31,7 @@
   <Target Name="_ImportSharedResources"
           BeforeTargets="_ForwardSharedResourcesToGenerator"
           Condition="'$(SkipSharedResourceResolution)' != 'true'">
-    <Exec Command="spire resource import" />
+    <Exec Command="spire resource import --yes" />
   </Target>
 
   <!-- Query the CLI for resolved resources and forward to the source generator -->


### PR DESCRIPTION
## Summary

- **MSBuild target** now passes `--yes` to `spire resource import`, preventing Spectre.Console from throwing "Failed to read input in non-interactive mode" when invoked during `aspire run` builds
- **Git clone** now forwards stdout/stderr to the console instead of using CliWrap's internal pipes, fixing SIGPIPE (exit code 141) when cloning external repositories and showing clone progress to the user

## Test plan

- [x] Verify `aspire run` on a project with external resources completes without interactive prompts
- [x] Verify manual `spire resource import` still prompts for confirmation when cloning without `--yes`
- [x] Verify clone progress output is visible during both MSBuild and interactive import

🤖 Generated with [Claude Code](https://claude.com/claude-code)