### PR TITLE
feat: respect branch parameter in external resource auto-clone

### DIFF
--- a/src/cli/Commands/Resource/Handlers/ResourceImportHandler.cs
+++ b/src/cli/Commands/Resource/Handlers/ResourceImportHandler.cs
@@ -165,7 +165,7 @@ public sealed class ResourceImportHandler
         CancellationToken cancellationToken)
     {
         _console.WriteLine();
-        _console.MarkupLine($"[bold]Cloning external repository:[/] {external.Url}...");
+        _console.MarkupLine($"[bold]Cloning external repository:[/] {external.Url} (branch: {external.Branch})...");
 
         // Determine clone location
         var repoName = GetRepoNameFromUrl(external.Url);
@@ -208,7 +208,7 @@ public sealed class ResourceImportHandler
             }
 
             _console.MarkupLine($"  Cloning to {clonePath}");
-            await _gitService.CloneRepositoryAsync(external.Url, clonePath, cancellationToken);
+            await _gitService.CloneRepositoryAsync(external.Url, clonePath, external.Branch, cancellationToken);
         }
 
         // Recursively import from cloned repo

--- a/src/cli/Services/Git/GitService.cs
+++ b/src/cli/Services/Git/GitService.cs
@@ -20,13 +20,15 @@ public sealed class GitService : IGitService
     }
 
     /// <inheritdoc />
-    public async Task<GitRepository> CloneRepositoryAsync(string repositoryUrl, string path, CancellationToken cancellationToken)
+    public async Task<GitRepository> CloneRepositoryAsync(string repositoryUrl, string path, string? branch = null, CancellationToken cancellationToken = default)
     {
         var cli = await _cliResolver.ResolveAsync(cancellationToken);
 
+        var branchArg = !string.IsNullOrEmpty(branch) ? $" --branch {branch}" : "";
+
         var arguments = cli == "gh"
-            ? $"repo clone {repositoryUrl} {path}"
-            : $"clone {repositoryUrl} {path}";
+            ? $"repo clone {repositoryUrl} {path}" + (!string.IsNullOrEmpty(branch) ? $" -- --branch {branch}" : "")
+            : $"clone{branchArg} {repositoryUrl} {path}";
 
         await CliWrap.Cli.Wrap(cli)
             .WithArguments(arguments)

--- a/src/cli/Services/Git/IGitService.cs
+++ b/src/cli/Services/Git/IGitService.cs
@@ -10,8 +10,9 @@ public interface IGitService
     /// </summary>
     /// <param name="repositoryUrl">The URL of the Git repository to clone.</param>
     /// <param name="path">The local path where the repository should be cloned.</param>
+    /// <param name="branch">The branch to clone. When null, the repository default branch is used.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
-    Task<GitRepository> CloneRepositoryAsync(string repositoryUrl, string path, CancellationToken cancellationToken);
+    Task<GitRepository> CloneRepositoryAsync(string repositoryUrl, string path, string? branch = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Retrieves information about a Git repository.

--- a/tests/cli/TestHelpers/TestGitService.cs
+++ b/tests/cli/TestHelpers/TestGitService.cs
@@ -19,12 +19,12 @@ public sealed class TestGitService : IGitService
     }
 
     /// <inheritdoc/>
-    public Task<GitRepository> CloneRepositoryAsync(string repositoryUrl, string path, CancellationToken cancellationToken)
+    public Task<GitRepository> CloneRepositoryAsync(string repositoryUrl, string path, string? branch = null, CancellationToken cancellationToken = default)
     {
         var repo = new GitRepository
         {
             RootPath = path,
-            CurrentBranch = "main",
+            CurrentBranch = branch ?? "main",
             LatestCommitHash = "abc123",
             IsDirty = false
         };

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/tags/v\\d+\\.\\d+"


### PR DESCRIPTION
## Summary
- Add `branch` parameter to `IGitService.CloneRepositoryAsync` so callers can specify which branch to clone
- Pass `external.Branch` through from `ResourceImportHandler` during auto-clone of external resources
- Supports both `git clone --branch` and `gh repo clone -- --branch` syntax
- Bump version to 0.2.0

## Test plan
- [x] Existing external resource tests updated for new signature
- [x] New `Import_WithExternalResourceBranch_ClonesBranch` test verifies branch passthrough
- [x] All 334 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)