### PR TITLE
feat: improve modes command with Space/Enter interaction

### DIFF
--- a/tests/cli/Modes/ModesIntegrationSpecs.cs
+++ b/tests/cli/Modes/ModesIntegrationSpecs.cs
@@ -61,10 +61,7 @@ public class ModesIntegrationSpecs : IAsyncDisposable
 
         var console = new TestConsole();
         console.Interactive();
-        // Exit immediately
-        console.Input.PushKey(ConsoleKey.DownArrow);
-        console.Input.PushKey(ConsoleKey.DownArrow);
-        console.Input.PushKey(ConsoleKey.Enter);
+        console.Input.PushKey(ConsoleKey.Enter); // Confirm immediately
 
         var writer = new TestSharedResourcesWriter(configPath);
         var globalReader = Substitute.For<IGlobalSharedResourcesReader>();
@@ -77,8 +74,8 @@ public class ModesIntegrationSpecs : IAsyncDisposable
 
         // Assert
         await Assert.That(result).IsEqualTo(0);
-        await Assert.That(console.Output).Contains("[Container] postgres");
-        await Assert.That(console.Output).Contains("[Project] my-service");
+        await Assert.That(console.Output).Contains("postgres");
+        await Assert.That(console.Output).Contains("my-service");
     }
 
     [Test]
@@ -89,11 +86,8 @@ public class ModesIntegrationSpecs : IAsyncDisposable
 
         var console = new TestConsole();
         console.Interactive();
-        // Toggle postgres then exit
-        console.Input.PushKey(ConsoleKey.Enter);       // Select postgres
-        console.Input.PushKey(ConsoleKey.DownArrow);
-        console.Input.PushKey(ConsoleKey.DownArrow);
-        console.Input.PushKey(ConsoleKey.Enter);       // Exit
+        console.Input.PushKey(ConsoleKey.Spacebar); // Toggle postgres
+        console.Input.PushKey(ConsoleKey.Enter);    // Confirm
 
         var writer = new TestSharedResourcesWriter(configPath);
         var globalReader = Substitute.For<IGlobalSharedResourcesReader>();


### PR DESCRIPTION
## Summary
- Replace `SelectionPrompt` loop with a `Live` display and custom key handling for the interactive `modes` command
- **Space** toggles the highlighted resource's mode inline (no re-prompting)
- **Enter** confirms and saves all changes at once
- **Escape** cancels without saving
- Changes are batched: only modified resources are persisted, and double-toggling correctly results in no save

## Test plan
- [x] All 337 existing + new tests pass
- [x] Manually run `spire modes` and verify Space toggles, Enter confirms, Escape cancels
- [x] Verify toggling multiple resources in a single session saves all changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)