### PR TITLE
docs: restructure README, add detailed docs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,108 @@
+# Architecture
+
+How Spire connects the CLI, MSBuild targets, source generator, and Aspire runtime.
+
+## Build-Time Flow
+
+When you build an AppHost that references `Shirubasoft.Spire.Hosting`, four MSBuild targets run before compilation:
+
+```
+_EnsureSpireCliInstalled  (if SpireAutoInstallCli=true)
+        ↓
+_CheckSpireCliAvailability
+        ↓
+_ImportSharedResources    (spire resource import --yes)
+        ↓
+_ForwardSharedResourcesToGenerator  (spire resource list → SharedResources.g.json)
+        ↓
+    CoreCompile           (source generator reads SharedResources.g.json)
+```
+
+1. **`_EnsureSpireCliInstalled`** — Runs `dotnet tool install -g spire.cli` if `SpireAutoInstallCli` is `true`. Warns but doesn't fail if installation fails.
+2. **`_CheckSpireCliAvailability`** — Verifies `spire --version` succeeds. Fails the build if the tool isn't found.
+3. **`_ImportSharedResources`** — Runs `spire resource import --yes` to sync `.aspire/settings.json` into the global config. Also resolves external repository references.
+4. **`_ForwardSharedResourcesToGenerator`** — Runs `spire resource list`, writes the JSON output to `$(IntermediateOutputPath)/SharedResources.g.json`, and registers it as an `AdditionalFile` for the source generator.
+
+All targets are skipped if `SkipSharedResourceResolution` is `true`.
+
+## Source Generator
+
+The `SharedResourceGenerator` is a Roslyn `IIncrementalGenerator` that reads `SharedResources.g.json` and emits:
+
+### Per resource
+
+- **`{Name}Resource`** — A class extending `SharedResource` that represents the resource type.
+- **`Add{Name}()`** — An extension method on `IDistributedApplicationBuilder` that registers the resource. Reads configuration to determine mode, resolves the inner builder (container or project), and returns `IResourceBuilder<{Name}Resource>`.
+- **`{Name}ProjectMetadata`** — If a project path is available at build time, an `IProjectMetadata` implementation for Aspire's project discovery.
+
+### Global
+
+- **`AddSharedResourcesConfiguration()`** — Extension method on `IConfigurationBuilder` that injects the resolved JSON as an in-memory configuration source, making `resources:{id}:mode` available to `IConfiguration`.
+
+### Interceptor
+
+The source generator also emits **interceptors** for Aspire extension method calls on shared resource builders. When you write:
+
+```csharp
+builder.AddMyService().WithHttpEndpoint(targetPort: 8080);
+```
+
+The interceptor redirects `.WithHttpEndpoint()` to call it on the inner builder (container or project), then returns the shared resource builder to preserve fluent chaining. This is powered by the experimental `GetInterceptableLocation` API in Roslyn.
+
+## Runtime Types
+
+### `SharedResource`
+
+A decorator that wraps an inner `IResource` (either `ContainerResource` or `ProjectResource`) and implements all common Aspire interfaces:
+
+- `IResourceWithEnvironment`
+- `IResourceWithArgs`
+- `IResourceWithEndpoints`
+- `IResourceWithWaitSupport`
+- `IResourceWithProbes`
+- `IComputeResource`
+
+### `SharedResourceBuilder<T>`
+
+Wraps an `IResourceBuilder<IResource>` to provide mode-aware configuration while preserving the generic type `T` through Aspire's fluent API chains.
+
+### `SharedResourceExtensions`
+
+Provides `ConfigureContainer` and `ConfigureProject` extension methods for mode-scoped configuration:
+
+```csharp
+builder.AddMyService()
+    .ConfigureContainer(b => b.WithHttpEndpoint(targetPort: 8080))
+    .ConfigureProject(b => b.WithHttpsEndpoint(targetPort: 5001));
+```
+
+These are **not intercepted** — they receive the typed inner builder directly and only execute when the resource is in the matching mode.
+
+## Solution Structure
+
+```
+src/
+  core/               Domain models (SharedResource, configs, settings)
+  cli/                CLI tool (System.CommandLine, "spire" command)
+  hosting/            Runtime types for Aspire AppHost + MSBuild targets
+  source-generator/   Roslyn IIncrementalGenerator (netstandard2.0)
+tests/                Mirrors src/ structure
+schemas/              JSON schemas for config validation
+sample/               Example multi-project Aspire setup
+```
+
+## Key Interfaces
+
+| Interface | Purpose |
+|-----------|---------|
+| `IGitService` | Git operations (repo root, branch, commit) |
+| `IContainerImageService` | Container build, tag, push, existence checks |
+| `IImageTagGenerator` | Generates commit, branch, and latest tags |
+| `IRepositorySharedResourcesReader` | Reads `.aspire/settings.json` |
+| `IGlobalSharedResourcesReader` | Reads global config |
+| `ISharedResourcesWriter` | Writes both global and repo configs |
+| `ICommandRunner` | CLI process execution (wraps CliWrap) |
+| `IContainerRuntimeResolver` | Detects docker/podman availability |
+| `IProjectAnalyzer` | Analyzes `.csproj` files |
+| `IDockerfileAnalyzer` | Analyzes Dockerfiles |
+| `IGitSettingsDetector` | Detects git repo URL and default branch |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,0 +1,145 @@
+# CLI Reference
+
+Complete reference for all Spire CLI commands, arguments, and options.
+
+## spire build
+
+Build container images for shared resources.
+
+```bash
+spire build [options]
+```
+
+| Option | Short | Type | Default | Description |
+|--------|-------|------|---------|-------------|
+| `--ids` | | `string[]` | | Resource IDs to build. Builds all if omitted. |
+| `--global` | `-g` | `bool` | `false` | Build all resources from global config. |
+| `--force` | `-f` | `bool` | `false` | Rebuild even if the commit-tagged image already exists. |
+
+**Resolution order** when no `--ids` are provided:
+
+1. If `--global` is set, builds all resources with container mode settings from global config.
+2. If inside a git repo, loads resources from `.aspire/settings.json` and filters to those with container mode in global config.
+3. Otherwise, prompts the user.
+
+**Image tags**: Each build produces three tags — `commit:<hash>`, `branch:<sanitized-name>`, and `latest`. If the commit tag already exists, the build is skipped unless `--force` is used.
+
+## spire modes
+
+Toggle Project/Container mode for shared resources.
+
+```bash
+spire modes [options]
+```
+
+| Option | Short | Type | Default | Description |
+|--------|-------|------|---------|-------------|
+| `--id` | `-i` | `string` | | Resource ID (for non-interactive use). |
+| `--mode` | `-m` | `Mode` | | Target mode: `Container` or `Project`. |
+
+**Interactive mode** (no options): displays a menu of all resources with their current modes and lets you toggle one.
+
+**Non-interactive mode**: both `--id` and `--mode` must be provided together.
+
+## spire resource generate
+
+Generate a shared resource definition from an existing project or container.
+
+```bash
+spire resource generate <path> [options]
+```
+
+| Argument | Type | Required | Description |
+|----------|------|----------|-------------|
+| `path` | `string` | Yes | Path to a `.csproj` file, `Dockerfile`, or directory containing either. |
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--id` | `string` | | Resource identifier. Prompted interactively if not provided. |
+| `--image-name` | `string` | | Override the container image name (defaults to project name). |
+| `--image-registry` | `string` | | Override the image registry (defaults to `docker.io`). |
+| `--yes` | `bool` | `false` | Skip confirmation prompts. |
+
+**What it does**:
+
+1. Analyzes the path for a `.csproj` or `Dockerfile`.
+2. Detects git repository settings (URL, default branch).
+3. Creates both global (`~/.aspire/spire/aspire-shared-resources.json`) and repository (`.aspire/settings.json`) configurations.
+
+## spire resource import
+
+Import shared resources from `.aspire/settings.json` files in the current git repository into the global config.
+
+```bash
+spire resource import [options]
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--yes` | `bool` | `false` | Skip confirmation prompts. |
+| `--force` | `bool` | `false` | Overwrite existing resources in global config. |
+
+Must be run from within a git repository. Also resolves **external resources** — repositories referenced in the `externalResources` section of `.aspire/settings.json` are cloned to `~/.aspire/spire/{repo-slug}/` and their resources are imported recursively.
+
+## spire resource list
+
+List all registered shared resources.
+
+```bash
+spire resource list
+```
+
+No options. Outputs JSON to stdout, suitable for piping to other tools or consumption by the source generator.
+
+## spire resource info
+
+Show detailed information about a single shared resource.
+
+```bash
+spire resource info --id <id>
+```
+
+| Option | Short | Type | Required | Description |
+|--------|-------|------|----------|-------------|
+| `--id` | `-i` | `string` | Yes | The resource identifier. |
+
+## spire resource remove
+
+Remove a shared resource from both global config and repository settings.
+
+```bash
+spire resource remove --id <id> [options]
+```
+
+| Option | Short | Type | Default | Description |
+|--------|-------|------|---------|-------------|
+| `--id` | `-i` | `string` | *(required)* | The resource identifier. |
+| `--yes` | `-y` | `bool` | `false` | Skip confirmation prompt. |
+
+## spire resource clear
+
+Clear all shared resources, or specific ones.
+
+```bash
+spire resource clear [options]
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--ids` | `string[]` | | Resource IDs to clear. Clears all if omitted. |
+| `--include-repo` | `bool` | `false` | Also clear from repository settings (`.aspire/settings.json`). |
+| `--yes` | `bool` | `false` | Skip confirmation prompt. |
+
+## spire override
+
+Override resource configurations for the current git repository or globally.
+
+```bash
+spire override
+```
+
+> This command is currently a placeholder with no subcommands implemented.
+
+## Exit Codes
+
+All commands return `0` on success and `1` on error.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,116 @@
+# Configuration
+
+Spire uses a layered configuration system with three levels: global, repository-scoped overrides, and per-repo settings files.
+
+## Configuration Files
+
+### `.aspire/settings.json` (repository config)
+
+The portable, version-controlled source of truth. Lives in each AppHost's `.aspire/` directory and uses **relative paths**.
+
+```json
+{
+  "resources": {
+    "my-service": {
+      "mode": "Container",
+      "containerMode": {
+        "imageName": "my-service",
+        "imageRegistry": "docker.io",
+        "imageTag": "latest",
+        "buildCommand": "dotnet publish",
+        "buildWorkingDirectory": "./src/MyService"
+      },
+      "projectMode": {
+        "projectPath": "./src/MyService/MyService.csproj"
+      }
+    }
+  },
+  "externalResources": [
+    {
+      "url": "https://github.com/org/other-repo.git",
+      "branch": "main"
+    }
+  ]
+}
+```
+
+**External resources** let you reference services from other repositories. On `spire resource import`, these repos are cloned to `~/.aspire/spire/{repo-slug}/` and their resources are imported recursively.
+
+### `~/.aspire/spire/aspire-shared-resources.json` (global config)
+
+Aggregates all resources across repositories with **absolute paths**. This is the runtime state used by the source generator and CLI commands.
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/shirubasoft/spire/main/schemas/shared-resources-global.schema.json",
+  "resources": {
+    "my-service": {
+      "mode": "Container",
+      "containerMode": { ... },
+      "projectMode": { ... },
+      "gitRepository": {
+        "url": "https://github.com/org/repo.git",
+        "defaultBranch": "main"
+      }
+    }
+  }
+}
+```
+
+### `~/.aspire/spire/{repo-slug}/aspire-shared-resources.json` (repository overrides)
+
+Per-repository overrides with absolute paths. Created by CLI commands to customize resource settings for a specific consuming repository.
+
+## Configuration Layering
+
+Configuration is resolved with increasing priority:
+
+1. **Global config** — base resource definitions
+2. **Repository overrides** — per-repo customizations
+3. **Environment variables** (`ASPIRE_*`) — runtime overrides
+
+## Which Commands Affect Which Files
+
+| Command | `.aspire/settings.json` | Global config |
+|---------|------------------------|---------------|
+| `resource generate` | Creates/updates | Updates |
+| `resource import` | Reads | Updates |
+| `resource remove` | Removes entry | Removes entry |
+| `resource clear` | Clears (with `--include-repo`) | Clears |
+| `resource list` | — | Reads |
+| `resource info` | — | Reads |
+
+## MSBuild Properties
+
+Set these in your AppHost `.csproj` or `Directory.Build.props`.
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `SkipSharedResourceResolution` | `false` | Skip all Spire MSBuild targets (CLI check, import, source generation). |
+| `SpireAutoInstallCli` | `false` | Auto-install or update the `spire` CLI tool at build time. |
+| `EnableSdkContainerSupport` | `true` | Enables .NET SDK container support (set by Spire props). |
+| `InterceptorsNamespaces` | `Spire.Hosting.Generated` | Namespace for interceptor-generated code (set by Spire props). |
+
+### Automatic CLI Install
+
+Set `SpireAutoInstallCli` to `true` in your AppHost project:
+
+```xml
+<PropertyGroup>
+  <SpireAutoInstallCli>true</SpireAutoInstallCli>
+</PropertyGroup>
+```
+
+When enabled, the build runs `dotnet tool install -g spire.cli` before checking CLI availability. If the install fails (e.g., no network), the build continues and falls back to the normal availability check.
+
+## JSON Schemas
+
+Spire provides JSON schemas for configuration validation:
+
+| Schema | Validates |
+|--------|-----------|
+| [`aspire-settings.schema.json`](../schemas/aspire-settings.schema.json) | `.aspire/settings.json` files |
+| [`shared-resources-global.schema.json`](../schemas/shared-resources-global.schema.json) | Global config (`~/.aspire/spire/aspire-shared-resources.json`) |
+| [`shared-resources.schema.json`](../schemas/shared-resources.schema.json) | Shared definitions (referenced by the above schemas) |
+
+Use the `$schema` property in your JSON files to enable editor validation and autocompletion.


### PR DESCRIPTION
## Summary
- Refactored README to be a concise quick-start guide and index to detailed documentation
- Created `docs/cli-reference.md` with complete command, flag, and option reference for all CLI commands
- Created `docs/configuration.md` covering config files, layering, MSBuild properties, and JSON schemas
- Created `docs/architecture.md` documenting the build-time flow, source generator, and runtime types
- Audited all CLI commands against source code and documented missing flags (`--force`, `--yes`, `--image-name`, `--image-registry`, `--include-repo`, `--ids` on clear) and the `override` command placeholder

## Test plan
- [ ] Verify all documented CLI commands and flags match actual behavior
- [ ] Verify all relative links in README resolve correctly on GitHub
- [ ] Verify docs/ folder links work from README

🤖 Generated with [Claude Code](https://claude.com/claude-code)