### PR TITLE
feat: tag images with full registry name and improve source image detection

### DIFF
--- a/src/cli/Services/Containers/ContainerImageService.cs
+++ b/src/cli/Services/Containers/ContainerImageService.cs
@@ -89,17 +89,13 @@ public sealed class ContainerImageService : IContainerImageService
     }
 
     /// <inheritdoc />
-    public async Task TagImageAsync(string sourceImage, IEnumerable<string> tags, CancellationToken cancellationToken)
+    public async Task TagImageAsync(string sourceImage, string targetBaseImage, IEnumerable<string> tags, CancellationToken cancellationToken)
     {
         var runtime = await _runtimeResolver.ResolveAsync(cancellationToken);
 
-        // Extract registry and image name from source image
-        var colonIndex = sourceImage.LastIndexOf(':');
-        var baseImage = colonIndex > 0 ? sourceImage[..colonIndex] : sourceImage;
-
         foreach (var tag in tags)
         {
-            var targetImage = $"{baseImage}:{tag}";
+            var targetImage = $"{targetBaseImage}:{tag}";
             var result = await _commandRunner.RunAsync(
                 runtime,
                 $"tag {sourceImage} {targetImage}",

--- a/src/cli/Services/Containers/IContainerImageService.cs
+++ b/src/cli/Services/Containers/IContainerImageService.cs
@@ -31,10 +31,11 @@ public interface IContainerImageService
     Task<bool> TagExistsAsync(string registry, string imageName, string tag, CancellationToken cancellationToken);
 
     /// <summary>
-    /// Tags an existing image with additional tags.
+    /// Tags an existing image with additional tags under a target base image name.
     /// </summary>
-    /// <param name="sourceImage">The full source image reference (e.g., "registry/name:tag").</param>
-    /// <param name="tags">The tags to apply to the image.</param>
+    /// <param name="sourceImage">The full source image reference (e.g., "name:tag" or "registry/name:tag").</param>
+    /// <param name="targetBaseImage">The target base image name including registry (e.g., "registry/name").</param>
+    /// <param name="tags">The tags to apply to the target base image.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
-    Task TagImageAsync(string sourceImage, IEnumerable<string> tags, CancellationToken cancellationToken);
+    Task TagImageAsync(string sourceImage, string targetBaseImage, IEnumerable<string> tags, CancellationToken cancellationToken);
 }

--- a/tests/cli/Commands/Build/BuildHandlerSpecs.cs
+++ b/tests/cli/Commands/Build/BuildHandlerSpecs.cs
@@ -64,6 +64,10 @@ public class ValidResourceBuildSpecs
         containerService.TagExistsAsync("docker.io", "my-service", "abc1234", Arg.Any<CancellationToken>())
             .Returns(false);
 
+        // Source image exists after build (without registry, latest tag)
+        containerService.TagExistsAsync("", "my-service", "latest", Arg.Any<CancellationToken>())
+            .Returns(true);
+
         var globalReader = Substitute.For<IGlobalSharedResourcesReader>();
         globalReader.GetSharedResourcesAsync(Arg.Any<CancellationToken>())
             .Returns(resources);
@@ -352,6 +356,10 @@ public class ForceRebuildSpecs
         containerService.TagExistsAsync("docker.io", "my-service", "abc1234", Arg.Any<CancellationToken>())
             .Returns(true);
 
+        // Source image exists after build (without registry, latest tag)
+        containerService.TagExistsAsync("", "my-service", "latest", Arg.Any<CancellationToken>())
+            .Returns(true);
+
         var globalReader = Substitute.For<IGlobalSharedResourcesReader>();
         globalReader.GetSharedResourcesAsync(Arg.Any<CancellationToken>())
             .Returns(resources);
@@ -426,6 +434,10 @@ public class ExistingBranchTagSpecs
         // Commit tag does NOT exist (branch tag existence doesn't matter)
         containerService.TagExistsAsync("docker.io", "my-service", "abc1234", Arg.Any<CancellationToken>())
             .Returns(false);
+
+        // Source image exists after build (without registry, latest tag)
+        containerService.TagExistsAsync("", "my-service", "latest", Arg.Any<CancellationToken>())
+            .Returns(true);
 
         var globalReader = Substitute.For<IGlobalSharedResourcesReader>();
         globalReader.GetSharedResourcesAsync(Arg.Any<CancellationToken>())
@@ -588,7 +600,7 @@ public class MultipleResourceBuildSpecs
             });
 
         containerService.TagExistsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(false);
+            .Returns(callInfo => string.IsNullOrEmpty(callInfo.ArgAt<string>(0)));
 
         var globalReader = Substitute.For<IGlobalSharedResourcesReader>();
         globalReader.GetSharedResourcesAsync(Arg.Any<CancellationToken>())
@@ -681,7 +693,7 @@ public class BuildAllFromRepoSpecs
             });
 
         containerService.TagExistsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(false);
+            .Returns(callInfo => string.IsNullOrEmpty(callInfo.ArgAt<string>(0)));
 
         var globalReader = Substitute.For<IGlobalSharedResourcesReader>();
         globalReader.GetSharedResourcesAsync(Arg.Any<CancellationToken>())
@@ -769,7 +781,7 @@ public class BuildAllFromGlobalSpecs
             });
 
         containerService.TagExistsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(false);
+            .Returns(callInfo => string.IsNullOrEmpty(callInfo.ArgAt<string>(0)));
 
         var globalReader = Substitute.For<IGlobalSharedResourcesReader>();
         globalReader.GetSharedResourcesAsync(Arg.Any<CancellationToken>())
@@ -892,7 +904,7 @@ public class BuildAllSkipsNonBuildableSpecs
             });
 
         containerService.TagExistsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(false);
+            .Returns(callInfo => string.IsNullOrEmpty(callInfo.ArgAt<string>(0)));
 
         var globalReader = Substitute.For<IGlobalSharedResourcesReader>();
         globalReader.GetSharedResourcesAsync(Arg.Any<CancellationToken>())


### PR DESCRIPTION
## Summary
- Images are now tagged with the full `registry/name:tag` format (e.g., `docker.io/my-api:abc1234`) instead of just `name:tag`
- Added `FindSourceImageAsync` that tries 6 source image candidates (without/with registry prefix, latest/commit/branch tags) to reliably find the built image regardless of build tool behavior
- `TagImageAsync` now accepts an explicit `targetBaseImage` parameter instead of deriving it from the source image

## Test plan
- [x] All 232 CLI tests pass
- [ ] Verify `spire build` with a dotnet publish-based project (creates image without registry prefix)
- [ ] Verify `spire build` with a docker build-based project (may create image with registry prefix)
- [ ] Verify `docker images` shows tags in `registry/name:tag` format after build

🤖 Generated with [Claude Code](https://claude.com/claude-code)